### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/nijisanji-stream-playlist-creator/security/code-scanning/8](https://github.com/legnoh/nijisanji-stream-playlist-creator/security/code-scanning/8)

The problem is that the workflow lacks an explicit `permissions` block, meaning the GITHUB_TOKEN will get default repo/org permissions, which could be too permissive. The fix is to add a `permissions` block specifying the minimal set your workflow needs. The minimal secure default is `contents: read`. In this workflow, no steps need any write permissions: the repo is checked out, dependencies installed, a file is created and an artifact is uploaded. None of these steps need write permissions for repo contents or issues, etc. Thus, add a `permissions` key at the workflow's top level (after `name:` and before `on:`), with `contents: read`. This ensures all jobs have only read access to repository contents unless otherwise overridden.

To implement, insert these lines after `name: CI` (line 1):

```yaml
permissions:
  contents: read
```

No further imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
